### PR TITLE
feat: actの導入によるGitHub Actionsのローカルテスト環境構築

### DIFF
--- a/.cursor/rules/create-branch.mdc
+++ b/.cursor/rules/create-branch.mdc
@@ -19,3 +19,9 @@ git checkout main
 git pull
 git switch -c {{種類}}/#{{issue number}}/{{概要}}
 ```
+
+- ブランチ作る時、issue番号がなければ、聞いて。
+- issue番号を聞いたら、以下のコマンドでissueの内容を確認して。それを元に、ブランチを作成して。
+```
+gh issue view {{issue番号}} | cat
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,13 @@
 	],
 	"service": "app",
 	"workspaceFolder": "/app",
-	"settings": {},
-	"extensions": [
-		"golang.go",
-		"42crunch.vscode-openapi"
-	]
+	"customizations": {
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"golang.go",
+				"42crunch.vscode-openapi"
+			]
+		}
+	}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: "CI"
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "**.go"
@@ -17,10 +18,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: generate secret key in JWT
-      run: | 
+      run: |
         echo "${{ secrets.JWT_SECRET_KEY }}" > ./auth/certificate/secret.pem
         chmod 444 ./auth/certificate/secret.pem
-        
     - name: generate public key in JWT
       run: |
         echo "${{ secrets.JWT_PUBLIC_KEY }}" > ./auth/certificate/public.pem
@@ -29,11 +29,18 @@ jobs:
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v2
       with:
+        # GitHub Actions用のトークンを使用してGitHubのAPIにアクセスするための認証情報
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        # golangci-lintの実行オプション - 設定ファイルを指定し、全てのパッケージをチェック
         golangci_lint_flags: "--config=./.golangci.yml ./..."
-        fail_on_error: true
+        # エラーが検出された場合にCIを失敗させる
+        fail_level: error
+        # レビューコメントをPull Requestに直接投稿する形式で結果を報告
         reporter: "github-pr-review"
+        # 警告レベル以上の問題を報告する
         level: warning
+        go_version_file: './go.mod'
+        golangci_lint_version: latest
   test:
     name: "Run test"
     runs-on: ubuntu-latest
@@ -73,10 +80,21 @@ jobs:
     # https://medium.com/@s0k0mata/github-actions-and-go-the-new-cache-feature-in-actions-setup-go-v4-and-what-to-watch-out-for-aeea373ed07d
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
+      id: setup-go
       with:
         go-version-file: './go.mod'
+    - name: Cache mysqldef binary
+      id: cache-mysqldef
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/bin/mysqldef
+        key: ${{ runner.os }}-mysqldef-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-mysqldef-
     - name: go module install
-      if: ${{ steps.setup-go.outputs.cache-hit != 'true' }}
+      if: ${{ steps.cache-mysqldef.outputs.cache-hit != 'true' }}
       run: |
         go install github.com/sqldef/sqldef/cmd/mysqldef@latest
     - name: Migration
@@ -93,3 +111,5 @@ jobs:
     - run: go test ./... -coverprofile=coverage.out
     - name: report coverage
       uses: k1LoW/octocov-action@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env
 secret.pem
 public.pem
+.secrets

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,15 @@
-linters-settings:
-  gocyclo:
-    min-complexity: 30
-  misspell:
-    locale: US
+version: "2"
 
 linters:
-  disable-all: true
   enable:
-    - goimports
     - unused
     - errcheck
     - gocognit
     - gocyclo
-    - gofmt
     - govet
     - misspell
     - staticcheck
     - whitespace
     - zerologlint
+    - gocyclo
+    - misspell

--- a/.secrets.example
+++ b/.secrets.example
@@ -1,0 +1,6 @@
+# 一行で
+JWT_SECRET_KEY=
+# 一行で
+JWT_PUBLIC_KEY=
+# gh auth token
+GITHUB_TOKEN=

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN go install github.com/air-verse/air@latest \
   && go install honnef.co/go/tools/cmd/staticcheck@latest \
   && go install golang.org/x/tools/cmd/goimports@latest \
   && go install github.com/matryer/moq@latest \
-  && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
+  && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest \
   && go install github.com/google/wire/cmd/wire@latest \
   && go install go.uber.org/mock/mockgen@latest \
   && go install github.com/xo/xo@latest

--- a/Makefile
+++ b/Makefile
@@ -15,50 +15,50 @@ DB_NAME=point_app
 DB_TEST_NAME=point_app_test
 
 .PHONY: build
-build: ## Build docker image to deploy
+build: ## デプロイ用のDockerイメージをビルド
 	docker image build \
 		-t ${ECR_REGISTRY}/point-app-backend:latest \
 		-t ${ECR_REGISTRY}/point-app-backend:${IMAGE_TAG}  \
 		--target deploy ./
 
 .PHONY: build-up
-build-up: ## Build docker image and up container
+build-up: ## Dockerイメージをビルドしてコンテナを起動
 	docker compose up -d --build
 
 .PHONY: push
-push: ## push to ECR
+push: ## ECRにプッシュ
 	aws ecr --region ap-northeast-1 get-login-password | docker login --username AWS --password-stdin https://${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com/point-app-backend
 	docker image push -a ${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com/point-app-backend
 
 .PHONY: in
-in: ## Appのコンテナに入る（ホスト）
+in: ## アプリケーションのコンテナに入る（ホスト）
 	docker compose exec app sh
 
 .PHONY: up
-up: ## Do docker compose up with hot reload（ホスト）
+up: ## ホットリロード付きでdocker compose upを実行（ホスト）
 	docker compose up -d
 
 .PHONY: down
-down: ## Do docker compose down（ホスト）
+down: ## docker compose downを実行（ホスト）
 	@docker compose down
 
 .PHONY: format
-log: ## Tail docker compose logs（ホスト）
+log: ## Docker composeのログを表示（ホスト）
 	@docker compose logs app -f
 
 .PHONY: ps
-ps: ## Check container status（ホスト）
+ps: ## コンテナの状態を確認（ホスト）
 	docker compose ps
 
 .PHONY: rsa 
 rsa: down build-up ## 全てのコンテナを削除して、ビルドして、起動
 
 .PHONY: dry-migrate
-dry-migrate: ## Try migration（マイグレーション時に発行されるDDL確認）
+dry-migrate: ## マイグレーションの試行（マイグレーション時に発行されるDDL確認）
 	mysqldef -u ${DB_USER} -p ${DB_PASSWORD} -h ${DB_HOST} -P ${DB_PORT} ${DB_NAME} --dry-run < ./_tools/mysql/schema.sql
 
 .PHONY: migrate
-migrate:  ## Execute migration（コンテナ）
+migrate:  ## マイグレーションを実行（コンテナ）
 	@mysqldef -u ${DB_USER} -p ${DB_PASSWORD} -h ${DB_HOST} -P ${DB_PORT} ${DB_NAME} < ./_tools/mysql/schema.sql
 	@if [ ${GO_ENV} == development ]; then \
 		mysqldef -u ${DB_USER} -p ${DB_PASSWORD} -h ${DB_HOST} -P ${DB_PORT} ${DB_TEST_NAME} < ./_tools/mysql/schema.sql; \
@@ -68,13 +68,13 @@ migrate:  ## Execute migration（コンテナ）
 seed: ## データ挿入（コンテナ）
 	mariadb --skip-ssl ${DB_NAME} -h ${DB_HOST} -u ${DB_USER} -p${DB_PASSWORD} < ./_tools/mysql/seed.sql 
 
-model: ## model作成
+model: ## モデル作成
 	rm -rf ./repository/entities
 	mkdir -p ./repository/entities
 	xo schema 'mysql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/${DB_NAME}?parseTime=true&sql_mode=ansi' -o ./repository/entities --go-field-tag='json:"{{ .SQLName }}" db:"{{ .SQLName }}"'
 
 .PHONY: rdm
-rdm: ## 送信メールを見る
+rdm: ## 送信メールを確認
 	@if [ ${CONTAINER_ENV} ]; then \
 		curl -v http://aws:4566/_aws/ses/ | jq . | tail -n 18 | head -n 16; \
 	else \
@@ -82,13 +82,13 @@ rdm: ## 送信メールを見る
 	fi
 
 .PHONY: create-key
-create-key: ## JWTに必要なkeyを作成する
+create-key: ## JWTに必要なキーを作成
 	openssl genrsa 4096 > ./auth/certificate/secret.pem
 	openssl rsa -pubout < ./auth/certificate/secret.pem > ./auth/certificate/public.pem
 
 .PHONY: format
-format: ## フォーマット
-	# フォーマット
+format: ## コードフォーマット
+	@echo "フォーマット"
 	@if [ ${CONTAINER_ENV} ]; then \
 		gofmt -l -s -w .; \
 		goimports -w -l .; \
@@ -100,7 +100,7 @@ format: ## フォーマット
 
 .PHONY: lint
 lint: format ## リンター(golangci-lint)
-	# リンター
+	@echo "リンター"
 	@if [ ${CONTAINER_ENV} ]; then \
 		golangci-lint run; \
 	else \
@@ -109,7 +109,7 @@ lint: format ## リンター(golangci-lint)
 
 
 .PHONY: moq
-moq: ## mock作成(コンテナ内)
+moq: ## モック作成(コンテナ内)
 	# サービスのモック生成中
 	@docker compose exec app moq -fmt goimports -out ./handler/moq_test.go ./handler \
 					RegisterUserService \
@@ -138,13 +138,13 @@ moq: ## mock作成(コンテナ内)
 	@docker compose exec app moq -fmt goimports -out ./service/repogitory_moq_test.go -skip-ensure -pkg service ./repository Beginner Preparer Execer Queryer
 
 .PHONY: mock
-mock: ## mock作成
+mock: ## モック作成
 	mockgen -source=./batch/controller/usecase.go -destination=./batch/controller/_mock/mock_usecase.go
 	mockgen -source=./repository/repository.go -destination=./repository/_mock/mock_repository.go
 	mockgen -source=./domain/interface.go -destination=./domain/_mock/mock_interface.go
 
 .PHONY: test
-test: ## テスト
+test: ## テスト実行
 	# テスト実行中
 	@if [ ${CONTAINER_ENV} ]; then \
 		go test -cover -race -shuffle=on ./...; \
@@ -153,7 +153,7 @@ test: ## テスト
 	fi
 
 .PHONY: coverage
-coverage: ## make coverage カバレッジファイル作成・表示（ホスト側）
+coverage: ## カバレッジファイル作成・表示（ホスト側）
 	# テスト実行中
 	@docker compose exec app go test -cover ./... -coverprofile=cover.out
 	# HTMLに変換中
@@ -163,11 +163,11 @@ coverage: ## make coverage カバレッジファイル作成・表示（ホス�
 	@open ./tmp/cover.html
 
 .PHONY: wire
-wire: ## api用のDIファイル生成
+wire: ## API用のDIファイル生成
 	@wire ./router
 
 .PHONY: wire-b
-wire-b: ## batch用のDIファイル生成
+wire-b: ## バッチ用のDIファイル生成
 	@wire ./batch/wire
 
 .PHONY: batch
@@ -179,10 +179,18 @@ batch: ## バッチ用アプリケーションのビルド
 	fi
 
 .PHONY: db
-db: ## dbに入る
+db: ## データベースに入る
 	@docker compose exec db mysql ${DB_NAME}
 
+.PHONY: env
+env: ## 環境変数を表示
+	@cp .secrets.example .secrets
+
+.PHONY: act
+act: ## テストを実行
+	act pull_request --secret-file .secrets --container-architecture linux/amd64
+
 .PHONY: help
-help: ## Show options
+help: ## オプションを表示
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/hack-31/point-app-backend
 
-go 1.23
+go 1.23.0
+
+toolchain go1.23.4
+
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/aws/aws-sdk-go v1.44.150

--- a/repository/user.go
+++ b/repository/user.go
@@ -128,7 +128,6 @@ func (r *Repository) DeleteUserByID(ctx context.Context, db Execer, ID model.Use
 func (r *Repository) UpdatePassword(ctx context.Context, db Execer, email, pass *string) error {
 	sql := `UPDATE users SET password = ? WHERE email = ?`
 
-
 	_, err := db.ExecContext(ctx, sql, pass, email)
 	if err != nil {
 		return errors.Wrap(err, "failed to update password in user repo")

--- a/repository/user_test.go
+++ b/repository/user_test.go
@@ -129,7 +129,6 @@ func TestRepository_users_GetAll(t *testing.T) {
 }
 
 func TestRepository_users_GetUserByID(t *testing.T) {
-
 	c := clock.FixedClocker{
 		IsAsia: true,
 	}


### PR DESCRIPTION
# issue

closes #161 #166

# 変更内容

- CIワークフローの改善
  - workflow_dispatchトリガーの追加
  - golangci-lintの設定改善
  - mysqldefのキャッシュ設定追加

- 開発環境の設定更新
  - devcontainer.jsonの設定更新
  - .gitignoreに.secretsを追加
  - golangci-lintの設定更新
  - Dockerfileのgolangci-lintバージョン更新
  - Makefileの日本語化とactコマンド追加
  - go.modのtoolchain指定追加

- コードのリファクタリングとドキュメント更新
  - repository/user.goの不要な空行削除
  - repository/user_test.goの不要な空行削除
  - create-branch.mdcのブランチ作成ルール更新

- シークレット設定ファイルの追加
  - .secrets.exampleファイルを追加

# 影響範囲

- CIワークフローの実行時間が改善される
- ローカルでのGitHub Actionsテストが可能になる
- 開発環境の設定が更新される

# テスト

- CIワークフローが正常に実行されることを確認
- actコマンドでローカルテストが実行できることを確認

# 動作要件

- actのインストール


- シークレットの設定


# 補足

- actコマンドの実行にはDockerが必要です
- シークレットの設定は必ず行ってください
