### PR TITLE
Go 1.24へのアップデート

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.23.1 
+golang 1.24.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ----------------------------------------------
 # ビルド用環境
 # ----------------------------------------------
-FROM golang:1.23-bullseye AS deploy-builder
+FROM golang:1.24-bullseye AS deploy-builder
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ CMD ["./app"]
 # ----------------------------------------------
 # 開発環境
 # ----------------------------------------------
-FROM golang:1.23-alpine AS dev
+FROM golang:1.24-alpine AS dev
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ in: ## アプリケーションのコンテナに入る（ホスト）
 
 .PHONY: up
 up: ## ホットリロード付きでdocker compose upを実行（ホスト）
-	docker compose up -d
+	docker compose up -d app db cache aws
 
 .PHONY: down
 down: ## docker compose downを実行（ホスト）

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/hack-31/point-app-backend
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.4
+toolchain go1.24
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
# issue

close #169

# 変更内容

Go 1.23.0から1.24へアップデートしました。

- .tool-versions: golang 1.23.1 → 1.24.4
- go.mod: go 1.23.0 → 1.24
- go.mod: toolchain go1.23.4 → go1.24
- Dockerfile: golang:1.23-bullseye → golang:1.24-bullseye
- Dockerfile: golang:1.23-alpine → golang:1.24-alpine
- Makefile: docker compose up -d → docker compose up -d app db cache aws

# 影響範囲

- air-verse/airのインストールが可能になります
- Goの最新機能とセキュリティアップデートの恩恵を受けられます
- Go 1.24の新機能が使用可能になります

# テスト

- Dockerビルドの確認
- air-verse/airのインストール確認
- 既存機能の動作確認

# 動作要件

特になし

# 補足

Go 1.24は安定版でセキュリティアップデートとパフォーマンス改善が含まれています。
air-verse/airがGo 1.24以上を要求するため、このアップデートが必要でした。
